### PR TITLE
Update the :uuid module to be compatible with newest version of deps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =============
 
+# 2.0.1
+* Update the `:uuid` package to its newest version now referenced as `:elixir_uuid`
+
 # 2.0.0
 * Update to Elixir 1.4
 * Update to Wit API 20160526

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Wit.Mixfile do
 
   def project do
     [app: :elixir_wit,
-     version: "2.0.0",
+     version: "2.0.1",
      elixir: "~> 1.4",
      description: description(),
      build_embedded: Mix.env == :prod,
@@ -36,7 +36,7 @@ defmodule Wit.Mixfile do
     [
       {:poison, "~> 3.0"},
       {:httpotion, "~> 3.0.0"},
-      {:uuid, "~> 1.1"},
+      {:elixir_uuid, "~> 1.2"},
       {:inch_ex, ">= 0.0.0", only: :docs},
 
       #Dev dependencies


### PR DESCRIPTION
This is supposedly supposed to fix #14 and allow projects requiring elixir_wit alongside other recent packages to compile with no issue